### PR TITLE
added logic  to training program controller to complete ticket 9

### DIFF
--- a/bangazon-api/app/controllers/training_programs_controller.rb
+++ b/bangazon-api/app/controllers/training_programs_controller.rb
@@ -35,7 +35,13 @@ class TrainingProgramsController < ApplicationController
 
   # DELETE /training_programs/1
   def destroy
-    @training_program.destroy
+    # if the start date is less sooner than today's date then delete
+    if @training_program.start_date < DateTime.now.to_date
+      @training_program.destroy
+    # if start date on or after today show following alert 
+    else
+      render html: "<script>alert('Programs may only be deleted prior to start date!')</script>"
+    end
   end
 
   private

--- a/bangazon-api/app/controllers/training_programs_controller.rb
+++ b/bangazon-api/app/controllers/training_programs_controller.rb
@@ -35,10 +35,10 @@ class TrainingProgramsController < ApplicationController
 
   # DELETE /training_programs/1
   def destroy
-    # if the start date is less sooner than today's date then delete
-    if @training_program.start_date < DateTime.now.to_date
+    # if the start date is after today's date then delete
+    if @training_program.start_date > DateTime.now.to_date
       @training_program.destroy
-    # if start date on or after today show following alert 
+    # if start date on or before today (class started) show following alert 
     else
       render html: "<script>alert('Programs may only be deleted prior to start date!')</script>"
     end


### PR DESCRIPTION
Description: 
- Added logic to have destroy function in training_program controller delete programs on prior to start date
Number of Fixes: -None Related Ticket(s):
	ticket #9 
Problem to Solve:
	•	None
Proposed Changes:
 - None
Expected Behavior:
	•	Delete if program start date is prior to today's date
- Alerts if program is on or after startdate
Steps to Test Solution
	1.	git pull origin master
	2.	git fetch
	3.	git checkout brooke-ticket9-logic
	4.	rails db:migrate
	
 
Deploy Notes:
	•	Deploy as stated in testing steps
	•	Test:
1) if destroy method works  for start date prior to today
{
  "training_program":
    {
      "start_date": "2017-10-22",
      "subject": "manners",
      "end_date": "2017-12-29",
      "max_occuancy": 25
}
}
      
) if destroy method alerts  for start date on or after to today
{
  "training_program":
    {
      "start_date": "2017-10-25",
      "subject": "manners",
      "end_date": "2017-12-29",
      "max_occuancy": 25
}
}
