### PR TITLE
ability to display customers who have no orders, or only customers wi…

### DIFF
--- a/bangazon-api/app/controllers/customers_controller.rb
+++ b/bangazon-api/app/controllers/customers_controller.rb
@@ -3,9 +3,20 @@ class CustomersController < ApplicationController
 
   # GET /customers
   def index
-    @customers = Customer.all
+    
+    # Ability to display customers who have not placed an order  
+    if params[:active] == "false"  
+      @customers = Customer.where(:active => false)
+      render json: @customers
+    elsif 
+        params[:active] == "true"  
+        @customers = Customer.where(:active => true)
+        render json: @customers
+    else
+      @customers = Customer.all
+      render json: @customers
+    end
 
-    render json: @customers
   end
 
   # GET /customers/1

--- a/bangazon-api/app/models/training_program.rb
+++ b/bangazon-api/app/models/training_program.rb
@@ -1,2 +1,3 @@
 class TrainingProgram < ApplicationRecord
+
 end

--- a/bangazon-api/db/seeds.rb
+++ b/bangazon-api/db/seeds.rb
@@ -14,9 +14,9 @@ Computer.create!([
   {purchase_date: "2017-02-22", decomission_date: "2017-05-13"}
 ])
 Customer.create!([
+  {last_name: "Ford", first_name: "Malcolm", date_customer_created: nil, active: false, last_date_used: nil, email: "brooke.wittenberg@gmail.com", street_address: "1414 Monetta Ave", city: "Nashville", us_state: "TN", zip_code: 37216},
   {last_name: "Ford", first_name: "Malcolm", date_customer_created: nil, active: true, last_date_used: nil, email: "brooke.wittenberg@gmail.com", street_address: "1414 Monetta Ave", city: "Nashville", us_state: "TN", zip_code: 37216},
-  {last_name: "Ford", first_name: "Malcolm", date_customer_created: nil, active: true, last_date_used: nil, email: "brooke.wittenberg@gmail.com", street_address: "1414 Monetta Ave", city: "Nashville", us_state: "TN", zip_code: 37216},
-  {last_name: "Ford", first_name: "Malcolm", date_customer_created: nil, active: true, last_date_used: nil, email: "brooke.wittenberg@gmail.com", street_address: "1414 Monetta Ave", city: "Nashville", us_state: "TN", zip_code: 37216}
+  {last_name: "Ford", first_name: "Malcolm", date_customer_created: nil, active: false, last_date_used: nil, email: "brooke.wittenberg@gmail.com", street_address: "1414 Monetta Ave", city: "Nashville", us_state: "TN", zip_code: 37216}
 ])
 
 


### PR DESCRIPTION
Description:
-added to the customers_controller.rb , logic for the ability to display customers w no orders (and only customers w one or more order).  Using Customers.where method. 

Number of Fixes:
-None

Related Ticket(s):
#11 

Problem to Solve:
None

Proposed Changes:
-None

Expected Behavior:
Read (filtered by)

Steps to Test Solution

git pull origin master
git fetch
git checkout adam-#11
rails db:migrate
rails db:seed
Deploy Notes:

Deploy as stated in testing steps
Test:
Get
